### PR TITLE
Document core training and data services

### DIFF
--- a/XREPORT/app/utils/learning/inference/generator.py
+++ b/XREPORT/app/utils/learning/inference/generator.py
@@ -48,6 +48,17 @@ class TextGenerator:
 
     # -------------------------------------------------------------------------
     def load_tokenizer_and_configuration(self) -> None | tuple[Any, dict[str, Any]]:
+        """
+        Load the tokenizer associated with the current configuration.
+
+        Keyword arguments:
+            None.
+
+        Return value:
+            Tuple containing the tokenizer instance and a configuration map with
+            vocabulary parameters, or None when the tokenizer cannot be
+            instantiated.
+        """
         # Get tokenizer and related configuration
         tokenization = TokenizerHandler(self.configuration)
         if tokenization.tokenizer is None:
@@ -85,6 +96,20 @@ class TextGenerator:
         sequence: Any | np.ndarray,
         tokenizer_config: dict[Any, Any],
     ) -> str:
+        """
+        Convert a sequence of token ids into a human-readable report.
+
+        Keyword arguments:
+            index_lookup: Reverse vocabulary mapping token ids to their string
+                representation.
+            sequence: Batched tensor produced by the decoder containing token
+                ids.
+            tokenizer_config: Metadata describing start, end and padding
+                tokens.
+
+        Return value:
+            Normalized report string without tokenizer-specific special tokens.
+        """
         # convert indexes to token using tokenizer vocabulary
         # define special tokens and remove them from generated tokens list
         token_sequence = [
@@ -111,6 +136,17 @@ class TextGenerator:
         vocabulary: dict[Any, Any],
         image_path: str,
     ) -> str:
+        """
+        Decode a report with greedy search, selecting the best token each step.
+
+        Keyword arguments:
+            tokenizer_config: Metadata describing special tokens and indices.
+            vocabulary: Tokenizer vocabulary mapping tokens to indices.
+            image_path: Absolute path to the image used for inference.
+
+        Return value:
+            Generated report string produced by greedy decoding.
+        """
         # extract vocabulary from the tokenizers
         start_token = tokenizer_config["start_token"]
         end_token = tokenizer_config["end_token"]
@@ -166,6 +202,18 @@ class TextGenerator:
         image_path: str,
         beam_width: int = 3,
     ) -> str:
+        """
+        Decode a report with beam search to balance accuracy and diversity.
+
+        Keyword arguments:
+            tokenizer_config: Metadata describing special tokens and indices.
+            vocabulary: Tokenizer vocabulary mapping tokens to indices.
+            image_path: Absolute path to the image used for inference.
+            beam_width: Number of candidate sequences retained each step.
+
+        Return value:
+            Generated report string produced by beam-search decoding.
+        """
         start_token = tokenizer_config["start_token"]
         end_token = tokenizer_config["end_token"]
         start_token_idx = tokenizer_config["start_token_idx"]
@@ -240,6 +288,18 @@ class TextGenerator:
     def generate_radiological_reports(
         self, images_path: list[str], method: str = "greedy_search", **kwargs
     ) -> dict[str, Any] | None:
+        """
+        Generate radiology reports for a collection of input images.
+
+        Keyword arguments:
+            images_path: List of image paths queued for inference.
+            method: Registered decoding strategy (greedy_search or beam_search).
+            **kwargs: Optional hooks for thread management and progress updates.
+
+        Return value:
+            Mapping of image paths to generated reports, or None when the
+            tokenizer cannot be loaded.
+        """
         reports = {}
         tokenizers_info = self.load_tokenizer_and_configuration()
         if tokenizers_info is None:

--- a/XREPORT/app/utils/learning/metrics.py
+++ b/XREPORT/app/utils/learning/metrics.py
@@ -19,6 +19,16 @@ class MaskedSparseCategoricalCrossentropy(Loss):
 
     # -------------------------------------------------------------------------
     def call(self, y_true: Any, y_pred: Any) -> Any:
+        """
+        Compute sparse categorical cross-entropy ignoring padded positions.
+
+        Keyword arguments:
+            y_true: Ground truth tensor with token ids.
+            y_pred: Model predictions with probabilities per token.
+
+        Return value:
+            Masked loss value averaged over non-padding tokens.
+        """
         loss = self.loss(y_true, y_pred)
         mask = ops.not_equal(y_true, 0)
         mask = ops.cast(mask, dtype=loss.dtype)
@@ -51,6 +61,17 @@ class MaskedAccuracy(Metric):
     def update_state(
         self, y_true: Any, y_pred: Any, sample_weight: Any | None = None
     ) -> None:
+        """
+        Update cumulative accuracy considering only non-padding positions.
+
+        Keyword arguments:
+            y_true: Ground truth tensor with token ids.
+            y_pred: Model predictions with probabilities per token.
+            sample_weight: Optional tensor with per-sample weights.
+
+        Return value:
+            None.
+        """
         y_true = ops.cast(y_true, dtype=floatx())
         y_pred_argmax = ops.cast(ops.argmax(y_pred, axis=2), dtype=floatx())
         accuracy = ops.equal(y_true, y_pred_argmax)
@@ -73,10 +94,28 @@ class MaskedAccuracy(Metric):
 
     # -------------------------------------------------------------------------
     def result(self) -> Any:
+        """
+        Compute the mean accuracy accumulated across updates.
+
+        Keyword arguments:
+            None.
+
+        Return value:
+            Masked accuracy scalar.
+        """
         return self.total / (self.count + backend.epsilon())
 
     # -------------------------------------------------------------------------
     def reset_states(self) -> None:
+        """
+        Reset metric state variables to restart accumulation.
+
+        Keyword arguments:
+            None.
+
+        Return value:
+            None.
+        """
         self.total.assign(0)
         self.count.assign(0)
 

--- a/XREPORT/app/utils/learning/training/fitting.py
+++ b/XREPORT/app/utils/learning/training/fitting.py
@@ -27,6 +27,20 @@ class ModelTraining:
         checkpoint_path: str,
         **kwargs,
     ) -> tuple[Model, dict[str, Any]]:
+        """
+        Train the supplied model from scratch using the configured callbacks.
+
+        Keyword arguments:
+            model: Keras model configured for caption generation.
+            train_data: Dataset or generator yielding training batches.
+            validation_data: Dataset providing validation batches.
+            checkpoint_path: Directory used to persist checkpoints and logs.
+            **kwargs: Optional hooks for progress callbacks and worker threads.
+
+        Return value:
+            Tuple containing the trained model and a dictionary summarizing the
+            training history.
+        """
         total_epochs = self.configuration.get("epochs", 10)
         # add all callbacks to the callback list
         callbacks_list = initialize_callbacks_handler(
@@ -60,6 +74,21 @@ class ModelTraining:
         additional_epochs: int = 10,
         **kwargs,
     ) -> tuple[Model, dict[str, Any]]:
+        """
+        Resume a partially trained model and extend training for more epochs.
+
+        Keyword arguments:
+            model: Keras model instance restored from previous checkpoints.
+            train_data: Dataset or generator yielding training batches.
+            validation_data: Dataset providing validation batches.
+            checkpoint_path: Directory used to persist checkpoints and logs.
+            session: Serialized history returned by a previous training run.
+            additional_epochs: Extra epochs to execute beyond the stored state.
+            **kwargs: Optional hooks for progress callbacks and worker threads.
+
+        Return value:
+            Tuple containing the updated model and the merged training history.
+        """
         from_epoch = 0 if not session else session["epochs"]
         total_epochs = from_epoch + additional_epochs
         # add all callbacks to the callback list

--- a/XREPORT/app/utils/repository/database.py
+++ b/XREPORT/app/utils/repository/database.py
@@ -121,6 +121,15 @@ class XREPORTDatabase:
 
     # -------------------------------------------------------------------------
     def get_table_class(self, table_name: str) -> Any:
+        """
+        Retrieve the SQLAlchemy model mapped to the requested table name.
+
+        Keyword arguments:
+            table_name: Name of the table whose declarative class is required.
+
+        Return value:
+            Declarative model class associated with the table.
+        """
         for cls in Base.__subclasses__():
             if hasattr(cls, "__tablename__") and cls.__tablename__ == table_name:
                 return cls
@@ -128,6 +137,16 @@ class XREPORTDatabase:
 
     # -------------------------------------------------------------------------
     def upsert_dataframe(self, df: pd.DataFrame, table_cls) -> None:
+        """
+        Insert or update a DataFrame into the target table using batches.
+
+        Keyword arguments:
+            df: DataFrame with the records to persist.
+            table_cls: Declarative table model describing the destination.
+
+        Return value:
+            None.
+        """
         table = table_cls.__table__
         session = self.Session()
         try:
@@ -160,6 +179,15 @@ class XREPORTDatabase:
 
     # -------------------------------------------------------------------------
     def update_database_from_sources(self) -> pd.DataFrame | None:
+        """
+        Refresh the canonical radiography dataset from the CSV source file.
+
+        Keyword arguments:
+            None.
+
+        Return value:
+            DataFrame containing the ingested dataset, or None on failure.
+        """
         dataset = pd.read_csv(self.source_path, sep=";", encoding="utf-8")
         self.save_into_database(dataset, "RADIOGRAPHY_DATA")
 
@@ -167,6 +195,15 @@ class XREPORTDatabase:
 
     # -------------------------------------------------------------------------
     def load_from_database(self, table_name: str) -> pd.DataFrame:
+        """
+        Load the contents of a database table into a pandas DataFrame.
+
+        Keyword arguments:
+            table_name: Name of the table to export.
+
+        Return value:
+            DataFrame containing the table rows.
+        """
         with self.engine.connect() as conn:
             data = pd.read_sql_table(table_name, conn)
 
@@ -174,12 +211,32 @@ class XREPORTDatabase:
 
     # -------------------------------------------------------------------------
     def save_into_database(self, data: pd.DataFrame, table_name: str) -> None:
+        """
+        Replace the contents of a table with the provided dataset.
+
+        Keyword arguments:
+            data: DataFrame containing the new table rows.
+            table_name: Name of the table to overwrite.
+
+        Return value:
+            None.
+        """
         with self.engine.begin() as conn:
             conn.execute(sqlalchemy.text(f'DELETE FROM "{table_name}"'))
             data.to_sql(table_name, conn, if_exists="append", index=False)
 
     # -------------------------------------------------------------------------
     def upsert_into_database(self, data: pd.DataFrame, table_name: str) -> None:
+        """
+        Upsert records into a table using the model-specific unique constraint.
+
+        Keyword arguments:
+            data: DataFrame containing the new or updated records.
+            table_name: Name of the destination table.
+
+        Return value:
+            None.
+        """
         table_cls = self.get_table_class(table_name)
         self.upsert_dataframe(data, table_cls)
 
@@ -187,6 +244,16 @@ class XREPORTDatabase:
     def export_all_tables_as_csv(
         self, export_dir: str, chunksize: int | None = None
     ) -> None:
+        """
+        Export every database table to a CSV file on disk.
+
+        Keyword arguments:
+            export_dir: Directory where the CSV exports should be created.
+            chunksize: Optional chunk size to stream large tables.
+
+        Return value:
+            None.
+        """
         os.makedirs(export_dir, exist_ok=True)
         with self.engine.connect() as conn:
             for table in Base.metadata.sorted_tables:
@@ -226,6 +293,15 @@ class XREPORTDatabase:
 
     # -------------------------------------------------------------------------
     def delete_all_data(self) -> None:
+        """
+        Remove every record from all managed tables.
+
+        Keyword arguments:
+            None.
+
+        Return value:
+            None.
+        """
         with self.engine.begin() as conn:
             for table in reversed(Base.metadata.sorted_tables):
                 conn.execute(table.delete())

--- a/XREPORT/app/utils/services/process.py
+++ b/XREPORT/app/utils/services/process.py
@@ -69,6 +69,16 @@ class TokenizerHandler:
     def get_tokenizer(
         self, tokenizer_name: str | None = None
     ) -> None | tuple[Any, int]:
+        """
+        Resolve a Hugging Face tokenizer locally, downloading it if necessary.
+
+        Keyword arguments:
+            tokenizer_name: Identifier of the tokenizer to load.
+
+        Return value:
+            Tuple with the tokenizer instance and its vocabulary size, or None
+            when the name is missing.
+        """
         if tokenizer_name is None:
             return
 
@@ -83,6 +93,15 @@ class TokenizerHandler:
 
     # -------------------------------------------------------------------------
     def tokenize_text_corpus(self, data: pd.DataFrame) -> pd.DataFrame:
+        """
+        Tokenize the full report corpus using the configured tokenizer.
+
+        Keyword arguments:
+            data: DataFrame containing the raw textual reports.
+
+        Return value:
+            Updated DataFrame with an extra column storing input id sequences.
+        """
         # tokenize train and validation text using loaded tokenizer
         true_report_size = self.max_report_size + 1
         text = data["text"].to_list()


### PR DESCRIPTION
## Summary
- add focused docstrings to inference text generation helpers to clarify decoding behaviour
- expand documentation across data loading and tokenization utilities for training and inference
- document database persistence helpers and masking metrics for easier maintenance

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6903cdadbe78832f8e21ddbf03094bcb